### PR TITLE
styled div title instead of h2

### DIFF
--- a/src/embeds.ts
+++ b/src/embeds.ts
@@ -32,10 +32,10 @@ export async function replaceEmbed(app: App, embed: Node, settings: LinkRangeSet
 
 		embedHtml.setText("")
 
-    embedHtml.createEl("div", {
-      cls: ["embed-title", "markdown-embed-title"],
-      text: res.altText
-    });
+		embedHtml.createEl("div", {
+			cls: ["embed-title", "markdown-embed-title"],
+			text: res.altText
+		});
 
 		const linkDiv = embedHtml.createDiv({
 			cls: ["markdown-embed-link"],

--- a/src/embeds.ts
+++ b/src/embeds.ts
@@ -36,9 +36,10 @@ export async function replaceEmbed(app: App, embed: Node, settings: LinkRangeSet
 
 			embedHtml.setText("")
 
-			embedHtml.createEl("h2", {
+			embedHtml.createEl("div", {
+				cls: ["embed-title", "markdown-embed-title"],
 				text: res.altText
-			})
+			});
 
 			const linkDiv = embedHtml.createDiv({
 				cls: ["markdown-embed-link"],


### PR DESCRIPTION
Fix #17

Instead of H2 use `<div>` with CSS classes similar to what is generated by Obsidian for normal whole-file embed titles.